### PR TITLE
only use path up to query string for destination filename

### DIFF
--- a/lib/build_pack_utils/cloudfoundry.py
+++ b/lib/build_pack_utils/cloudfoundry.py
@@ -130,7 +130,7 @@ class CloudFoundryInstaller(object):
                               extract=True):
         self._log.debug("Installing direct [%s]", url)
         if not fileName:
-            fileName = url.split('/')[-1]
+            fileName = url.split('/')[-1].split('?')[0]
         if self._is_url(hsh):
             digest = self._dwn.download_direct(hsh)
         else:

--- a/lib/build_pack_utils/process.py
+++ b/lib/build_pack_utils/process.py
@@ -218,8 +218,12 @@ class Printer(object):
             lines = arg.split('\n')
             lines = [self._prefix() + l if l else l for l in lines]
             new_args.append('\n'.join(lines))
-
-        self.output.write(*new_args, **kwargs)
+        try:
+            self.output.write(*new_args, **kwargs)
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            self._log.error(
+                "Unicode Error while decoding line from process [%s]",
+                "Printer.write")
 
     def _prefix(self):
         time = datetime.now().strftime('%H:%M:%S')


### PR DESCRIPTION
if we use a signed url from amazon, the filename exceeds CF's filename limit of 254 characters.

I couldn't see which test I would need to update, sorry
